### PR TITLE
removed duplicate declaration

### DIFF
--- a/lib/clients/copyFactory/history.client.d.ts
+++ b/lib/clients/copyFactory/history.client.d.ts
@@ -69,22 +69,6 @@ declare type CopyFactorySubscriberOrProviderUser = {
  * CopyFactory strategy id and name
  */
 declare type CopyFactoryStrategyIdAndName = {
-
-  /**
-   * unique strategy id
-   */
-  id: String,
-
-  /**
-   * human-readable strategy name
-   */
-  name:string
-}
-
-/**
- * CopyFactory strategy id and name
- */
-declare type CopyFactoryStrategyIdAndName = {
   
   /**
    * unique strategy id


### PR DESCRIPTION
removed duplicate declaration for CopyFactoryTransaction due to TS2300: Duplicate identifier compilation error.